### PR TITLE
Add decktape PDF export for slide decks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # build output
 dist/
+dist-pdf/
 cv/build/
 
 # RenderCV outputs

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "copy:pdfs": "echo 'PDFs already copied via --pdf-path'",
     "preprocess:resume": "npm run validate:resume && node scripts/build-resume-variants.js",
     "validate:resume": "node scripts/validate-resume-main.js",
+    "export:slides": "node scripts/export-slides-pdf.js",
     "preview": "astro preview",
     "astro": "astro",
     "format": "prettier --write .",

--- a/scripts/export-slides-pdf.js
+++ b/scripts/export-slides-pdf.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Export a reveal.js slide deck to PDF via decktape.
+//
+// Needs a running server (dev or preview) serving the deck. The deck's
+// SlideLayout honors a `?pdf` query param: it strips on-screen chrome
+// (controls, progress, slide number, Astro dev toolbar) and pre-renders every
+// Mermaid diagram up front, so decktape never captures a half-drawn slide.
+//
+// Usage:
+//   node scripts/export-slides-pdf.js [slug] [outPath]
+//   SLIDES_BASE=http://localhost:4321 node scripts/export-slides-pdf.js gcc2026
+//
+// Defaults: slug=gcc2026, base=http://localhost:4331, out=dist-pdf/<slug>.pdf
+import { mkdirSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { spawnSync } from 'child_process';
+
+const slug = process.argv[2] || 'gcc2026';
+const out = resolve(process.argv[3] || `dist-pdf/${slug}.pdf`);
+const base = process.env.SLIDES_BASE || 'http://localhost:4331';
+const url = `${base}/slides/${slug}?pdf=1`;
+
+const res = await fetch(url).catch(() => null);
+if (!res || !res.ok) {
+  console.error(`✗ Cannot reach ${url} (status ${res?.status ?? 'no server'}).`);
+  console.error('  Start the server first: `npm run dev` (or `npm run preview`).');
+  process.exit(1);
+}
+
+mkdirSync(dirname(out), { recursive: true });
+console.log(`Exporting ${url} -> ${out}`);
+
+// 960x700 matches the deck's slide dimensions; --pause gives async renders
+// (Mermaid) time to settle before each slide is captured.
+const r = spawnSync(
+  'npx',
+  ['-y', 'decktape@latest', 'reveal', url, out, '--size', '960x700', '--pause', '800'],
+  { stdio: 'inherit' }
+);
+process.exit(r.status ?? 1);

--- a/src/layouts/SlideLayout.astro
+++ b/src/layouts/SlideLayout.astro
@@ -255,6 +255,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
         const Reveal = (
           await import('https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/dist/reveal.esm.js')
         ).default;
+        // Expose globally so external tools (decktape PDF export) can drive the deck.
+        window.Reveal = Reveal;
         const RevealHighlight = (
           await import(
             'https://cdn.jsdelivr.net/npm/reveal.js@4.5.0/plugin/highlight/highlight.esm.js'
@@ -266,37 +268,73 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
           )
         ).default;
 
-        // Render Mermaid diagrams lazily, per slide, once it is on screen.
-        // Mermaid measures the container width; an unsized slide (before Reveal
-        // lays out, or a hidden display:none slide) renders an empty graph, so
-        // we render only the visible slide's blocks. Load is guarded: decks
-        // without diagrams never fetch mermaid.
+        // PDF export mode (decktape passes ?pdf): strip on-screen chrome and
+        // pre-render every diagram so the exporter never captures a half-drawn slide.
+        const params = new URLSearchParams(window.location.search);
+        const pdfMode = params.has('pdf') || params.has('print-pdf');
+
+        // Mermaid measures container width; an unsized slide (before Reveal lays
+        // out, or a hidden display:none slide) renders an empty graph. Interactive
+        // mode renders only the visible slide; export mode renders all slides by
+        // temporarily forcing each visible. Load is guarded: decks without
+        // diagrams never fetch mermaid.
         let mermaid;
-        const renderMermaid = async (slide) => {
-          if (!slide) return;
-          const nodes = [...slide.querySelectorAll('.mermaid:not([data-processed])')];
-          if (!nodes.length) return;
+        const loadMermaid = async () => {
           if (!mermaid) {
             mermaid = (
               await import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs')
             ).default;
             mermaid.initialize({ startOnLoad: false });
           }
+          return mermaid;
+        };
+        const renderMermaid = async (slide) => {
+          if (!slide) return;
+          const nodes = [...slide.querySelectorAll('.mermaid:not([data-processed])')];
+          if (!nodes.length) return;
+          await loadMermaid();
           await mermaid.run({ nodes });
+        };
+        const renderAllMermaid = async () => {
+          for (const slide of document.querySelectorAll('.slides > section')) {
+            const nodes = [...slide.querySelectorAll('.mermaid:not([data-processed])')];
+            if (!nodes.length) continue;
+            await loadMermaid();
+            // visibility:hidden keeps layout width (display:none would not).
+            const prevDisplay = slide.style.display;
+            slide.style.display = 'block';
+            slide.style.visibility = 'hidden';
+            await mermaid.run({ nodes });
+            slide.style.display = prevDisplay;
+            slide.style.visibility = '';
+          }
         };
 
         await Reveal.initialize({
           hash: true,
-          controls: showControls,
-          progress: showProgress,
+          controls: showControls && !pdfMode,
+          progress: showProgress && !pdfMode,
           center: true,
           transition: transition,
-          slideNumber: 'c/t',
+          slideNumber: pdfMode ? false : 'c/t',
           plugins: [RevealHighlight, RevealMarkdown],
         });
 
-        Reveal.on('slidechanged', (e) => renderMermaid(e.currentSlide));
-        await renderMermaid(Reveal.getCurrentSlide());
+        if (pdfMode) {
+          const style = document.createElement('style');
+          style.textContent =
+            '.reveal .controls,.reveal .progress,.reveal .slide-number{display:none!important}' +
+            'astro-dev-toolbar{display:none!important}' +
+            // Drop image drop-shadows: captured at native slide width (~DPR 1)
+            // the blur compresses into a dark band instead of the soft shadow
+            // the upscaled live deck shows. The border alone defines the edge.
+            '.reveal img{box-shadow:none!important}';
+          document.head.appendChild(style);
+          await renderAllMermaid();
+        } else {
+          Reveal.on('slidechanged', (e) => renderMermaid(e.currentSlide));
+          await renderMermaid(Reveal.getCurrentSlide());
+        }
       })();
     </script>
   </body>


### PR DESCRIPTION
Adds a repeatable decktape-based PDF export for reveal.js slide decks, plus the rendering fixes needed for clean output.

## What's here
- **`scripts/export-slides-pdf.js`** — drives [decktape](https://github.com/astefanutti/decktape) over a running dev/preview server. `node scripts/export-slides-pdf.js [slug] [outPath]` (also `npm run export:slides`). Pre-flights the URL and points you at `npm run dev` if the server's down.
- **`?pdf` export mode in `SlideLayout.astro`** — when decktape loads the deck with `?pdf`, the layout:
  - strips on-screen chrome (controls, progress, slide number, Astro dev toolbar),
  - eagerly renders **every** Mermaid diagram up front (interactive mode renders lazily per-slide, which raced the exporter and produced blank diagrams),
  - drops image `box-shadow`s — decktape captures at native slide width (~DPR 1), where the blur compresses into a dark band instead of the soft shadow the upscaled live deck shows. Border alone defines the edge.
- **`window.Reveal` exposed** so decktape's reveal plugin can activate.
- **`dist-pdf/` gitignored** — generated PDFs aren't committed.

## Notes
- All export-only behavior is gated behind the `?pdf` query param; the live interactive deck is unchanged.
- Pre-existing, not addressed here: reveal.js JS is pinned to CDN 4.5.0 while CSS comes from local 5.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
